### PR TITLE
feat: Apply tanstack-query for guestbook state management and redesign Alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ dist/
 
 .DS_Store
 Thumbs.db
-.vscode/
+# .vscode/
 .idea/
 
 init.sql

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": "explicit",
+      "source.organizeImports": "explicit"
+    },
+    "prettier.requireConfig": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "typescript.preferences.preferTypeOnlyAutoImports": true
+  }
+  

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "@hookform/resolvers": "^3.3.4",
     "react-toastify": "^10.0.5",
     "zod": "^3.24.1",
-    "zustand": "^5.0.2"
+    "zustand": "^5.0.2",
+    "@tanstack/react-query": "^5.67.3"
   },
   "devDependencies": {
     "@types/node": "^20.11.19",

--- a/frontend/src/app/(auth)/sign-in/page.tsx
+++ b/frontend/src/app/(auth)/sign-in/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ChangeEvent, FormEvent, useState } from 'react';
 import { AuthForm } from '@/lib/components/auth/AuthForm';
 import { AuthInput } from '@/lib/components/auth/AuthInput';
-import { type SignInFormData } from '@/lib/types/auth';
 import { useAuth } from '@/lib/hooks/useAuth';
+import { type SignInFormData } from '@/lib/types/auth';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 export default function SignIn() {
   const { error, handleSignIn } = useAuth();

--- a/frontend/src/app/(auth)/sign-up/page.tsx
+++ b/frontend/src/app/(auth)/sign-up/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ChangeEvent, FormEvent, useState } from 'react';
 import { AuthForm } from '@/lib/components/auth/AuthForm';
 import { AuthInput } from '@/lib/components/auth/AuthInput';
-import { type SignUpFormData } from '@/lib/types/auth';
 import { useAuth } from '@/lib/hooks/useAuth';
+import { type SignUpFormData } from '@/lib/types/auth';
+import { ChangeEvent, FormEvent, useState } from 'react';
 
 export default function SignUp() {
   const { error, handleSignUp } = useAuth();

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
-import type { Metadata } from "next";
+import TQProvider from "@/lib/providers/TQProvider";
 import "@/styles/globals.css";
+import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -24,8 +25,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={pretendard.className}>
-        {children}
-        <ToastContainer />
+        <TQProvider>
+          {children}
+          <ToastContainer />
+        </TQProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -27,7 +27,19 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <TQProvider>
           {children}
-          <ToastContainer />
+          <ToastContainer
+            position="bottom-center"
+            autoClose={3000}
+            hideProgressBar
+            newestOnTop={true}
+            closeOnClick
+            limit={1}
+            icon={false}
+            rtl={false}
+            pauseOnFocusLoss={false}
+            draggable={false}
+            pauseOnHover={false}
+          />
         </TQProvider>
       </body>
     </html>

--- a/frontend/src/lib/components/auth/AuthForm.tsx
+++ b/frontend/src/lib/components/auth/AuthForm.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, ReactNode } from 'react';
 import Link from 'next/link';
+import { FormEvent, ReactNode } from 'react';
 
 type AuthFormProps = {
   title: string;

--- a/frontend/src/lib/components/ui/Alert.tsx
+++ b/frontend/src/lib/components/ui/Alert.tsx
@@ -1,5 +1,4 @@
 import { toast } from "react-toastify";
-// import AlertIcon from "@/assets/images/check-circle.svg";
 
 declare const window: Window &
     typeof globalThis & {

--- a/frontend/src/lib/components/ui/GuestbookInput.tsx
+++ b/frontend/src/lib/components/ui/GuestbookInput.tsx
@@ -1,43 +1,43 @@
 'use client';
 
-import { FormEvent, useState } from 'react';
-import { guestbookApi } from '@/api/api';
+import { useCreateGuestbookEntry } from '@/lib/hooks/useGuestbook';
 import { userStore } from '@/lib/store/userStore';
-
+import { FormEvent, useState } from 'react';
+import { Alert } from './Alert';
 
 const GuestbookInput = () => {
   const [content, setContent] = useState('');
-  const [error, setError] = useState('');
   const { user } = userStore();
+  const { mutate: createEntry, isPending } = useCreateGuestbookEntry();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!content.trim()) return;
 
-    try {
-      // 비로그인 유저 id, 임의 생성 로직 추가
-      const randomUserId = Math.floor(100000 + Math.random() * 900000);
-      const randomNickname = `Guest${String(randomUserId).slice(-4)}`;
+    // 비로그인 유저 id, 임의 생성 로직 추가
+    const randomUserId = Math.floor(100000 + Math.random() * 900000);
+    const randomNickname = `Guest${String(randomUserId).slice(-4)}`;
 
-      await guestbookApi.createGuestbook({ 
+    createEntry(
+      { 
         contents: content,
         user_id: user?.id || randomUserId,
         user_nickname: user?.nickname || randomNickname
-      });
-      setContent('');
-    } catch (err) {
-      setError('방명록 작성에 실패했습니다.');
-    }
+      },
+      {
+        onSuccess: () => {
+          setContent('');
+          Alert('방명록이 작성되었습니다.');
+        },
+        onError: () => {
+          Alert('방명록 작성에 실패했습니다.');
+        }
+      }
+    );
   };
 
   return (
     <div className="w-full">
-      {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          {error}
-        </div>
-      )}
-
       <form onSubmit={handleSubmit} className="mb-8">
         <div className="flex gap-2">
           <input
@@ -46,16 +46,19 @@ const GuestbookInput = () => {
             onChange={(e) => setContent(e.target.value)}
             placeholder="방명록을 작성해주세요"
             className="w-full flex-1 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            disabled={isPending}
           />
           <button
             type="submit"
-            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+            disabled={isPending}
           >
-            작성
+            {isPending ? '작성 중...' : '작성'}
           </button>
         </div>
       </form>
     </div>
   );
 }
+
 export default GuestbookInput;

--- a/frontend/src/lib/components/ui/GuestbookList.tsx
+++ b/frontend/src/lib/components/ui/GuestbookList.tsx
@@ -1,31 +1,21 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { guestbookApi, likesApi } from '@/api/api';
-import { Guestbook } from '@/lib/types/guestbook';
+import { useDeleteGuestbookEntry, useGuestbookEntries, useToggleLike, useUpdateGuestbookEntry } from '@/lib/hooks/useGuestbook';
 import { userStore } from '@/lib/store/userStore';
+import { Guestbook } from '@/lib/types/guestbook';
+import { useState } from 'react';
+import { Alert } from './Alert';
+import LoadingSpinner from './LoadingSpinner';
 
 const GuestbookList = () => {
-  const [guestbooks, setGuestbooks] = useState<Guestbook[]>([]);
-  const [error, setError] = useState('');
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editContent, setEditContent] = useState('');
   const { user } = userStore();
 
-  useEffect(() => {
-    fetchGuestbooks();
-  }, []);
-
-  const fetchGuestbooks = async () => {
-    try {
-      const response = await guestbookApi.getGuestbooks();
-      const data = Array.isArray(response.data) ? response.data : [];
-      setGuestbooks(data);
-    } catch (err) {
-      setError('방명록을 불러오는데 실패했습니다.');
-      setGuestbooks([]);
-    }
-  };
+  const { data: guestbooks = [], isPending, error } = useGuestbookEntries();
+  const { mutate: updateEntry, isPending: isUpdating } = useUpdateGuestbookEntry();
+  const { mutate: deleteEntry, isPending: isDeleting } = useDeleteGuestbookEntry();
+  const { mutate: toggleLike, isPending: isLiking } = useToggleLike();
 
   const handleEdit = (guestbook: Guestbook) => {
     if (user?.id !== guestbook.user_id) return;
@@ -33,14 +23,19 @@ const GuestbookList = () => {
     setEditContent(guestbook.contents);
   };
 
-  const handleSaveEdit = async (id: number) => {
-    try {
-      await guestbookApi.updateGuestbook(id, { contents: editContent });
-      setEditingId(null);
-      fetchGuestbooks();
-    } catch (err) {
-      setError('방명록 수정에 실패했습니다.');
-    }
+  const handleSaveEdit = (id: number) => {
+    updateEntry(
+      { id, contents: editContent },
+      {
+        onSuccess: () => {
+          setEditingId(null);
+          Alert('방명록이 수정되었습니다.');
+        },
+        onError: () => {
+          Alert('방명록 수정에 실패했습니다.');
+        }
+      }
+    );
   };
 
   const handleCancelEdit = () => {
@@ -48,34 +43,51 @@ const GuestbookList = () => {
     setEditContent('');
   };
 
-  const handleDelete = async (id: number) => {
-    try {
-      await guestbookApi.deleteGuestbook(id);
-      fetchGuestbooks();
-    } catch (err) {
-      setError('방명록 삭제에 실패했습니다.');
-    }
+  const handleDelete = (id: number) => {
+    if (!window.confirm('정말로 이 방명록을 삭제하시겠습니까?')) return;
+    
+    deleteEntry(id, {
+      onSuccess: () => {
+        Alert('방명록이 삭제되었습니다.');
+      },
+      onError: () => {
+        Alert('방명록 삭제에 실패했습니다.');
+      }
+    });
   };
 
-  const handleLike = async (id: number) => {
-    try {
-      await likesApi.updateLike(id);
-      fetchGuestbooks();
-    } catch (err) {
-      setError('좋아요 처리에 실패했습니다.');
+  const handleLike = (id: number, isLiked: boolean) => {
+    if (!user) {
+      Alert('로그인이 필요한 기능입니다.');
+      return;
     }
+    
+    toggleLike(
+      { id, isLiked },
+      {
+        onError: () => {
+          Alert('좋아요 처리에 실패했습니다.');
+        }
+      }
+    );
   };
+
+  if (isPending) {
+    return <div ><LoadingSpinner /></div>;
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+        방명록을 불러오는데 실패했습니다.
+      </div>
+    );
+  }
 
   return (
     <div className="w-full">
-      {error && (
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          {error}
-        </div>
-      )}
-
       <div className="space-y-4">
-        {guestbooks && guestbooks.length > 0 ? (
+        {guestbooks.length > 0 ? (
           guestbooks.map((guestbook) => (
             <div
               key={guestbook.id}
@@ -91,17 +103,20 @@ const GuestbookList = () => {
                         onChange={(e) => setEditContent(e.target.value)}
                         className="w-full p-2 border rounded"
                         rows={3}
+                        disabled={isUpdating}
                       />
                       <div className="mt-2 flex gap-2">
                         <button
                           onClick={() => handleSaveEdit(guestbook.id)}
-                          className="px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700"
+                          className="px-3 py-1 bg-indigo-600 text-white rounded hover:bg-indigo-700 disabled:opacity-50"
+                          disabled={isUpdating}
                         >
-                          저장
+                          {isUpdating ? '저장 중...' : '저장'}
                         </button>
                         <button
                           onClick={handleCancelEdit}
                           className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
+                          disabled={isUpdating}
                         >
                           취소
                         </button>
@@ -118,24 +133,27 @@ const GuestbookList = () => {
                 </div>
                 <div className="flex flex-col items-end gap-2">
                   <button
-                    onClick={() => handleLike(guestbook.id)}
-                    className="text-red-600 hover:text-red-800"
+                    onClick={() => handleLike(guestbook.id, guestbook.liked_by_user)}
+                    className={`${guestbook.liked_by_user ? 'text-red-600' : 'text-gray-400'} hover:text-red-800 disabled:opacity-50`}
+                    disabled={isLiking}
                   >
-                    좋아요 ({guestbook.likes || 0})
+                    좋아요 ({guestbook.likes})
                   </button>
                   {user?.id === guestbook.user_id && (
                     <div className="flex gap-2">
                       <button
                         onClick={() => handleEdit(guestbook)}
                         className="text-indigo-600 hover:text-indigo-800"
+                        disabled={isDeleting}
                       >
                         수정
                       </button>
                       <button
                         onClick={() => handleDelete(guestbook.id)}
                         className="text-red-600 hover:text-red-800"
+                        disabled={isDeleting}
                       >
-                        삭제
+                        {isDeleting ? '삭제 중...' : '삭제'}
                       </button>
                     </div>
                   )}

--- a/frontend/src/lib/components/ui/LoadingSpinner.tsx
+++ b/frontend/src/lib/components/ui/LoadingSpinner.tsx
@@ -1,0 +1,9 @@
+const LoadingSpinner = () => {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="h-10 w-10 animate-spin rounded-full border-4 border-solid border-gray-300 border-t-gray-900 tb:h-8 tb:w-8 mb:h-6 mb:w-6"></div>
+    </div>
+  );
+};
+
+export default LoadingSpinner;

--- a/frontend/src/lib/hooks/useAuth.ts
+++ b/frontend/src/lib/hooks/useAuth.ts
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { authApi } from '@/api/api';
+import { Alert } from '@/lib/components/ui/Alert';
 import { userStore } from '@/lib/store/userStore';
 import { signInSchema, signUpSchema, type SignInFormData, type SignUpFormData } from '@/lib/types/auth';
-import { Alert } from '@/lib/components/ui/Alert';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import { ZodError } from 'zod';
 
 export function useAuth() {

--- a/frontend/src/lib/hooks/useGuestbook.ts
+++ b/frontend/src/lib/hooks/useGuestbook.ts
@@ -1,0 +1,126 @@
+import { guestbookApi, likesApi } from "@/api/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Guestbook } from "../types/guestbook";
+
+// 방명록 목록 조회 훅
+export function useGuestbookEntries() {
+  return useQuery<Guestbook[]>({
+    queryKey: ["guestbook"],
+    queryFn: async () => {
+      const response = await guestbookApi.getGuestbooks();
+      return response.data;
+    }
+  });
+}
+
+// 방명록 생성 훅
+export function useCreateGuestbookEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: { contents: string; user_id: number; user_nickname: string }) => {
+      const response = await guestbookApi.createGuestbook(data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["guestbook"] });
+    }
+  });
+}
+
+// 방명록 수정 훅
+export function useUpdateGuestbookEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, contents }: { id: number; contents: string }) => {
+      const response = await guestbookApi.updateGuestbook(id, { contents });
+      return response.data;
+    },
+    onMutate: async (updated) => {
+      await queryClient.cancelQueries({ queryKey: ["guestbook"] });
+      const prevEntries = queryClient.getQueryData<Guestbook[]>(["guestbook"]) || [];
+
+      queryClient.setQueryData(["guestbook"], (oldEntries: Guestbook[] = []) =>
+        oldEntries.map((entry) => 
+          entry.id === updated.id ? { ...entry, contents: updated.contents } : entry
+        )
+      );
+
+      return { prevEntries };
+    },
+    onError: (_err, _updated, context) => {
+      queryClient.setQueryData(["guestbook"], context?.prevEntries);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["guestbook"] });
+    }
+  });
+}
+
+// 방명록 삭제 훅
+export function useDeleteGuestbookEntry() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await guestbookApi.deleteGuestbook(id);
+    },
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: ["guestbook"] });
+      const prevEntries = queryClient.getQueryData<Guestbook[]>(["guestbook"]) || [];
+
+      queryClient.setQueryData(
+        ["guestbook"],
+        prevEntries.filter((entry) => entry.id !== id)
+      );
+
+      return { prevEntries };
+    },
+    onError: (_err, _id, context) => {
+      queryClient.setQueryData(["guestbook"], context?.prevEntries);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["guestbook"] });
+    }
+  });
+}
+
+// 좋아요 토글 훅
+export function useToggleLike() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, isLiked }: { id: number; isLiked: boolean }) => {
+      if (isLiked) {
+        await likesApi.updateUnlike(id);
+      } else {
+        await likesApi.updateLike(id);
+      }
+    },
+    onMutate: async ({ id, isLiked }) => {
+      await queryClient.cancelQueries({ queryKey: ["guestbook"] });
+      const prevEntries = queryClient.getQueryData<Guestbook[]>(["guestbook"]) || [];
+
+      queryClient.setQueryData(["guestbook"], (oldEntries: Guestbook[] = []) =>
+        oldEntries.map((entry) => 
+          entry.id === id 
+            ? { 
+                ...entry, 
+                likes: isLiked ? entry.likes - 1 : entry.likes + 1,
+                liked_by_user: !isLiked
+              } 
+            : entry
+        )
+      );
+
+      return { prevEntries };
+    },
+    onError: (_err, _variables, context) => {
+      queryClient.setQueryData(["guestbook"], context?.prevEntries);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["guestbook"] });
+    }
+  });
+} 

--- a/frontend/src/lib/providers/TQProvider.tsx
+++ b/frontend/src/lib/providers/TQProvider.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export default function TQProvider({ children }: { children: ReactNode }) {
+  // useState를 사용해 클라이언트에서 단일 QueryClient 유지
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // 데이터 갱신 빈도 제어
+        refetchOnWindowFocus: false // 불필요한 API 호출 방지
+      }
+    }
+  }));
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/frontend/src/lib/types/guestbook.ts
+++ b/frontend/src/lib/types/guestbook.ts
@@ -4,5 +4,7 @@ export type Guestbook = {
   user_id: number;
   user_nickname: string;
   created_at: string;
-  likes?: number;
+  updated_at: string;
+  likes: number;
+  liked_by_user: boolean;
 }


### PR DESCRIPTION
### 작업 개요
- guestbook 기능에 tanstack-query를 도입 및 효율적인 서버 관리를 위한 구조 변경
- 사용자 피드백 전달을 위한 `customAlert` 디자인 개선
- 코드 저장 시 자동 정렬 및 import 정리를 위한 포맷팅 설정 적용

---

### 목적
- 서버 상태를 전역에서 일관되게 관리하고, 사용자 경험(UX)을 개선하기 위함
- 추후 방명록 기능 확장 및 수정 시 유지보수성과 확장성을 높이기 위한 기반 작업

---

### 주요 변경 사항
1. **tanstack-query 설치 및 적용**
   - `@tanstack/react-query` 설치
   - QueryClient 인스턴스를 생성하여 `TQProvider`로 감싼 뒤, `RootLayout`에 전역 적용

2. **guestbook 서버 상태 관리 개선**
   - 기존의 fetch/post 로직을 tanstack-query의 `useQuery`, `useMutation` 기반으로 재구성
   - 데이터 패칭 이후 `invalidateQueries`를 활용하여 상태를 자동 갱신하도록 처리

3. **customAlert 디자인 개선 및 적용**
   - 사용자 알림 유틸리티 개선 (색상, 위치, 사용성 등)
   - guestbook 관련 페이지에 customAlert 적용 완료

4. **코드 포맷팅 설정 적용**
   - VSCode 저장 시 자동 정렬/수정을 위한 `.vscode/settings.json` 기반 설정 활성화
   - Prettier & ESLint 기반 포맷팅 적용 (`imports`, `line length`, `spacing` 등)
