### PR TITLE
refactor: Update API routes and refactor likes error handling & guestbook hooks

### DIFF
--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -44,8 +44,8 @@ export const guestbookApi = {
 
 // 좋아요 관련 API
 export const likesApi = {
-  updateLike: (id: number) => API.put(`/api/guestbook/${id}/like`),
-  updateUnlike: (id: number) => API.put(`/api/guestbook/${id}/unlike`),
+  updateLike: (id: number, user_id: number) => API.put(`/api/likes/${id}`, { user_id, action: 'like' }),
+  updateUnlike: (id: number, user_id: number) => API.put(`/api/likes/${id}`, { user_id, action: 'unlike' }),
 };
 
 // 요청 인터셉터 - 토큰 추가

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -44,8 +44,22 @@ export const guestbookApi = {
 
 // 좋아요 관련 API
 export const likesApi = {
-  updateLike: (id: number, user_id: number) => API.put(`/api/likes/${id}`, { user_id, action: 'like' }),
-  updateUnlike: (id: number, user_id: number) => API.put(`/api/likes/${id}`, { user_id, action: 'unlike' }),
+  updateLike: (id: number, user_id: number) => 
+    API.put(`/api/likes/${id}`, { user_id, action: 'like' })
+      .then(response => {
+        if (response.status === 400) {
+          throw new Error('이미 좋아요를 누른 게시물입니다.');
+        }
+        return response;
+      }),
+  updateUnlike: (id: number, user_id: number) => 
+    API.put(`/api/likes/${id}`, { user_id, action: 'unlike' })
+      .then(response => {
+        if (response.status === 400) {
+          throw new Error('이미 좋아요를 취소한 게시물입니다.');
+        }
+        return response;
+      }),
 };
 
 // 요청 인터셉터 - 토큰 추가

--- a/frontend/src/lib/hooks/useGuestbook.ts
+++ b/frontend/src/lib/hooks/useGuestbook.ts
@@ -1,4 +1,5 @@
 import { guestbookApi, likesApi } from "@/api/api";
+import { userStore } from "@/lib/store/userStore";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Guestbook } from "../types/guestbook";
 
@@ -41,8 +42,8 @@ export function useUpdateGuestbookEntry() {
       await queryClient.cancelQueries({ queryKey: ["guestbook"] });
       const prevEntries = queryClient.getQueryData<Guestbook[]>(["guestbook"]) || [];
 
-      queryClient.setQueryData(["guestbook"], (oldEntries: Guestbook[] = []) =>
-        oldEntries.map((entry) => 
+      queryClient.setQueryData(["guestbook"], 
+        prevEntries.map((entry) => 
           entry.id === updated.id ? { ...entry, contents: updated.contents } : entry
         )
       );
@@ -50,7 +51,7 @@ export function useUpdateGuestbookEntry() {
       return { prevEntries };
     },
     onError: (_err, _updated, context) => {
-      queryClient.setQueryData(["guestbook"], context?.prevEntries);
+      queryClient.setQueryData(["guestbook"], context?.prevEntries || []);
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["guestbook"] });
@@ -70,15 +71,14 @@ export function useDeleteGuestbookEntry() {
       await queryClient.cancelQueries({ queryKey: ["guestbook"] });
       const prevEntries = queryClient.getQueryData<Guestbook[]>(["guestbook"]) || [];
 
-      queryClient.setQueryData(
-        ["guestbook"],
+      queryClient.setQueryData(["guestbook"], 
         prevEntries.filter((entry) => entry.id !== id)
       );
 
       return { prevEntries };
     },
     onError: (_err, _id, context) => {
-      queryClient.setQueryData(["guestbook"], context?.prevEntries);
+      queryClient.setQueryData(["guestbook"], context?.prevEntries || []);
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["guestbook"] });
@@ -89,21 +89,27 @@ export function useDeleteGuestbookEntry() {
 // 좋아요 토글 훅
 export function useToggleLike() {
   const queryClient = useQueryClient();
+  const { user } = userStore();
 
   return useMutation({
     mutationFn: async ({ id, isLiked }: { id: number; isLiked: boolean }) => {
-      if (isLiked) {
-        await likesApi.updateUnlike(id);
-      } else {
-        await likesApi.updateLike(id);
+      if (!user?.id) {
+        throw new Error('로그인이 필요한 기능입니다.');
       }
+
+      const response = await (isLiked 
+        ? likesApi.updateUnlike(id, user.id)
+        : likesApi.updateLike(id, user.id)
+      );
+
+      return response.data;
     },
     onMutate: async ({ id, isLiked }) => {
       await queryClient.cancelQueries({ queryKey: ["guestbook"] });
       const prevEntries = queryClient.getQueryData<Guestbook[]>(["guestbook"]) || [];
 
-      queryClient.setQueryData(["guestbook"], (oldEntries: Guestbook[] = []) =>
-        oldEntries.map((entry) => 
+      queryClient.setQueryData(["guestbook"], 
+        prevEntries.map((entry) => 
           entry.id === id 
             ? { 
                 ...entry, 
@@ -116,8 +122,8 @@ export function useToggleLike() {
 
       return { prevEntries };
     },
-    onError: (_err, _variables, context) => {
-      queryClient.setQueryData(["guestbook"], context?.prevEntries);
+    onError: (_error, _variables, context) => {
+      queryClient.setQueryData(["guestbook"], context?.prevEntries || []);
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ["guestbook"] });


### PR DESCRIPTION
### 작업 개요
- 전반적인 API 라우트 구조를 업데이트하고, 좋아요 API의 에러 핸들링을 개선했습니다.
- guestbook 관련 hooks를 정리하여 가독성과 재사용성을 높였습니다.

---

### 목적
- API 일관성을 높여 유지보수성을 개선하고, 사용자에게 명확한 피드백을 제공하기 위함
- guestbook 관련 코드의 구조를 단순화하여 재사용성과 가독성을 향상시키기 위함

---

### 주요 변경 사항
1. **API 라우트 구조 개선**
   - 엔드포인트 URL 명명 규칙 정리 (`/api/likes`, `/api/guestbook` 등) 및  API 구조 통일

2. **likes API 에러 핸들링 개선**
   - 예외 상황에 대한 명확한 상태 코드 및 메시지 반환
   - 클라이언트 측 디버깅을 위한 콘솔/서버 로그 구조 개선

3. **guestbook hooks 정리**
   - 중복 로직 제거 및 `useGuestbookQuery`, `useCreateGuestbook` 등 명확한 네이밍으로 변경